### PR TITLE
Playlist View

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Suitcase from './pages/Suitcase';
 import Troubleshoot from './pages/Troubleshoot';
 import TabBar from './components/TabBar';
 import { makeStyles } from '@material-ui/core/styles';
+import PlaylistPage from './components/PlaylistPage';
 
 const useStyles = makeStyles({
   root: {
@@ -19,18 +20,14 @@ function App() {
     <Router>
       <div>
         <Switch>
-          <Route path="/suitcase">
-            <Suitcase />
-          </Route>
-          <Route path="/favorites">
-            <Favorites />
-          </Route>
-          <Route path="/guides">
-            <Guides />
-          </Route>
-          <Route path="/troubleshoot">
-            <Troubleshoot />
-          </Route>
+          <Route exact path="/suitcase" component={Suitcase} />
+          <Route exact path="/favorites" component={Favorites} />
+          <Route exact path="/guides" component={Guides} />
+          <Route path={"/guides/:lessonId"}
+            render={props =>
+              <PlaylistPage lessonId={props.match.params.lessonId} />
+            } />
+          <Route path="/troubleshoot" component={Troubleshoot} />
         </Switch>
       </div>
       <TabBar />

--- a/src/components/PlaylistCard.tsx
+++ b/src/components/PlaylistCard.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Lesson } from '../store/lessonsSlice';
+import Card from '@material-ui/core/Card';
+
+type PlaylistCardProps = {
+  lesson: Lesson,
+}
+
+const PlaylistCard = ({ lesson }: PlaylistCardProps) => {
+
+  return (
+    <Card>
+      <h3>{lesson.title}</h3>
+      <h5>{} Article(s)</h5>
+      <h5>{} Video(s)</h5>
+      <p>{lesson.description}</p>
+    </Card>
+  );
+}
+
+export default PlaylistCard;

--- a/src/components/PlaylistPage.tsx
+++ b/src/components/PlaylistPage.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { RootState } from '../store/reducers';
+import PreviewCard from './PreviewCard';
+
+type PlaylistPageProps = {
+  lessonId: number,
+}
+
+const PlaylistPage = ({ lessonId }: PlaylistPageProps) => {
+  const lessons = useSelector((state: RootState) => state.lessons);
+  const resources = useSelector((state: RootState) => state.resources);
+  const currentLesson = lessons[lessonId]
+  return (
+    <div>
+      <h1>{currentLesson.title}</h1>
+      <h3>Description</h3>
+      <p>{currentLesson.description}</p>
+      <h3>You Will Learn</h3>
+      <ul>
+        {currentLesson.objectives.map((item) => <li>item</li>)}
+      </ul>
+      <h3>Content</h3>
+      {currentLesson.resourceIds.map((id) => {
+        if (id in resources) {
+          return < PreviewCard resource={resources[id]} resourceID={id} />
+        } else {
+          return <span />
+        }
+      })}
+    </div>
+  );
+}
+
+export default PlaylistPage;

--- a/src/pages/Guides.tsx
+++ b/src/pages/Guides.tsx
@@ -1,7 +1,39 @@
-import React, { Component } from 'react';
+import React from 'react';
+import PlaylistCard from '../components/PlaylistCard';
+import { useSelector } from 'react-redux';
+import { RootState } from '../store/reducers';
+import { Link } from 'react-router-dom';
+import { makeStyles, createStyles } from "@material-ui/core/styles"
 
-export default class Guides extends Component {
-  render() {
-    return <div>Guides</div>
+const styles = makeStyles(() => createStyles({
+  playlistScroll: {
+    display: "flex",
+    overflow: "scroll"
+  },
+  playlistCard: {
+    width: "200px"
   }
+}))
+
+function Guides({ match }) {
+  const lessons = useSelector((state: RootState) => state.lessons);
+  const classes = styles();
+
+  return (
+    <div>
+      <h1>Playlists</h1>
+      <div className={classes.playlistScroll}>
+        {Object.keys(lessons).map((key: any) => (
+          <Link to={`${match.url}/${key}`}>
+            <div className={classes.playlistCard}>
+              <PlaylistCard lesson={lessons[key]} />
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+
+  )
+
 }
+export default Guides;

--- a/src/store/initialStates.ts
+++ b/src/store/initialStates.ts
@@ -9,6 +9,21 @@ import { ResourcesSlice } from './resourcesSlice';
 import { UserSlice } from './userSlice';
 
 export const INITIAL_RESOURCES: ResourcesSlice = {
+  3: {
+    type: 'Video',
+    title: 'How the Fetal Doppler',
+    tags: ['Fetal Doppler', 'Setup'],
+    data: {
+      preview: 'this is a video preview ....',
+      watchUrl: 'https://youtube.com/watch?v=_______',
+      downloadUrl: '<s3 link here>',
+      fileSize: 13050, // File size in bytes
+      duration: 67 // Video duration in seconds
+    },
+    isFinished: true, // QUESTION: once viewed, or manually mark finished?
+    isCached: true,
+    isFavorited: true
+  },
   17: {
     type: 'Video',
     title: 'How to Use the Fetal Doppler',
@@ -42,9 +57,38 @@ export const INITIAL_RESOURCES: ResourcesSlice = {
 
 export const INITIAL_LESSONS: LessonsSlice = {
   6: {
+    title: 'The Title',
     description: 'A short description of this lesson',
     objectives: ['A list of', 'Things that the user', 'Will learn'],
     resourceIds: [3, 6, 8, 12],
+    isFinished: false
+  },
+  7: {
+    title: 'The Title 2 ',
+    description: 'A short description of this lesson 2 ',
+    objectives: ['A list of', 'Things that the user', 'Will learn'],
+    resourceIds: [3, 12],
+    isFinished: false
+  },
+  8: {
+    title: 'The Title 2 ',
+    description: 'A short description of this lesson 2 ',
+    objectives: ['A list of', 'Things that the user', 'Will learn'],
+    resourceIds: [3, 12],
+    isFinished: false
+  },
+  9: {
+    title: 'The Title 2 ',
+    description: 'A short description of this lesson 2 ',
+    objectives: ['A list of', 'Things that the user', 'Will learn'],
+    resourceIds: [3, 12],
+    isFinished: false
+  },
+  10: {
+    title: 'The Title 2 ',
+    description: 'A short description of this lesson 2 ',
+    objectives: ['A list of', 'Things that the user', 'Will learn'],
+    resourceIds: [3, 12],
     isFinished: false
   }
   // ...

--- a/src/store/initialStates.ts
+++ b/src/store/initialStates.ts
@@ -10,9 +10,9 @@ import { UserSlice } from './userSlice';
 
 export const INITIAL_RESOURCES: ResourcesSlice = {
   3: {
-    type: 'Video',
-    title: 'How the Fetal Doppler',
-    tags: ['Fetal Doppler', 'Setup'],
+    type: 'Video 3',
+    title: 'How to use Thermometer',
+    tags: ['Temperature', 'Setup'],
     data: {
       preview: 'this is a video preview ....',
       watchUrl: 'https://youtube.com/watch?v=_______',
@@ -24,8 +24,21 @@ export const INITIAL_RESOURCES: ResourcesSlice = {
     isCached: true,
     isFavorited: true
   },
+  8: {
+    type: 'Article',
+    title: 'Solar Installation',
+    tags: ['power'],
+    data: {
+      preview: 'this is an article preview ....',
+      textUrl: '<cloud firestore or s3 link here>',
+      fileSize: 13050 // QUESTION: file size on text resources?
+    },
+    isFinished: false, // QUESTION: once viewed, or manually mark finished?
+    isCached: false, // QUESTION: allow caching text resources?
+    isFavorited: true
+  },
   17: {
-    type: 'Video',
+    type: 'Video 17',
     title: 'How to Use the Fetal Doppler',
     tags: ['Fetal Doppler', 'Setup'],
     data: {
@@ -57,40 +70,33 @@ export const INITIAL_RESOURCES: ResourcesSlice = {
 
 export const INITIAL_LESSONS: LessonsSlice = {
   6: {
-    title: 'The Title',
+    title: 'Lesson 1',
     description: 'A short description of this lesson',
     objectives: ['A list of', 'Things that the user', 'Will learn'],
-    resourceIds: [3, 6, 8, 12],
+    resourceIds: [3, 8, 17, 23],
     isFinished: false
   },
   7: {
-    title: 'The Title 2 ',
+    title: 'Lesson 2',
     description: 'A short description of this lesson 2 ',
     objectives: ['A list of', 'Things that the user', 'Will learn'],
-    resourceIds: [3, 12],
+    resourceIds: [3],
     isFinished: false
   },
   8: {
-    title: 'The Title 2 ',
+    title: 'Lesson 3 with a very long title and much more',
     description: 'A short description of this lesson 2 ',
     objectives: ['A list of', 'Things that the user', 'Will learn'],
-    resourceIds: [3, 12],
+    resourceIds: [3, 8],
     isFinished: false
   },
   9: {
-    title: 'The Title 2 ',
+    title: 'Lesson 4 with a very long title and much more',
     description: 'A short description of this lesson 2 ',
     objectives: ['A list of', 'Things that the user', 'Will learn'],
-    resourceIds: [3, 12],
+    resourceIds: [1, 2, 4],
     isFinished: false
   },
-  10: {
-    title: 'The Title 2 ',
-    description: 'A short description of this lesson 2 ',
-    objectives: ['A list of', 'Things that the user', 'Will learn'],
-    resourceIds: [3, 12],
-    isFinished: false
-  }
   // ...
 };
 

--- a/src/store/lessonsSlice.ts
+++ b/src/store/lessonsSlice.ts
@@ -6,6 +6,7 @@ export type LessonsSlice = {
 };
 
 export type Lesson = {
+  title: string;
   description: string;
   objectives: string[];
   resourceIds: number[];


### PR DESCRIPTION
## 🖋 PR Description

Created Playlist Page, with components PlaylistCard and PlaylistPage. Also toggles between the Guide page and the Playlist page with correct props.

side-notes:
- holding off on most of styling until designs more finalized
- I still have to work on displaying number of articles and videos -- I wonder if it might be more useful to have them stored as properties in redux as well, since calculating them every time just for the playlist card might be a bit slow
- In regards to the full sprint task, I still have to look more into image loading and how to optimize that! 

### 🤳Screenshots (if applicable)
<img width="631" alt="Screen Shot 2020-10-28 at 11 21 47 AM" src="https://user-images.githubusercontent.com/46883811/97479807-e14c2600-190f-11eb-91bf-bbec01cc768a.png">
<img width="635" alt="Screen Shot 2020-10-28 at 11 22 02 AM" src="https://user-images.githubusercontent.com/46883811/97479809-e27d5300-190f-11eb-9df1-4e7ecce2d826.png">

### 🧪 Testing

npm start -- then you can click on Playlist Cards in the Guide Page

cc: @joelenelatief
