### PR TITLE
Theming

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,8 @@ import TabBar from './components/TabBar/TabBar';
 import { makeStyles } from '@material-ui/core/styles';
 import PlaylistPage from './components/Playlist/PlaylistPage';
 import SearchBar from './components/SearchBar/SearchBar';
+import { ThemeProvider } from '@material-ui/core/styles';
+import theme from './CustomStyles'; 
 
 const useStyles = makeStyles({
   navbar: {
@@ -21,6 +23,7 @@ const useStyles = makeStyles({
 function App() {
   const classes = useStyles();
   return (
+    <ThemeProvider theme={theme}>
     <Router>
       <SearchBar />
       <div>
@@ -37,6 +40,7 @@ function App() {
       </div>
       <TabBar />
     </Router>
+    </ThemeProvider>
   );
 }
 

--- a/src/CustomStyles.tsx
+++ b/src/CustomStyles.tsx
@@ -1,27 +1,65 @@
 import React from 'react';
 import { createMuiTheme, Theme } from '@material-ui/core/styles';
-
+import { Palette } from "@material-ui/core/styles/createPalette";
 
 declare module '@material-ui/core/styles/createPalette' {
     interface Palette {
-        myCustomColor: Palette['primary']; 
+      main?: Palette['primary']
+      general?: Palette['primary']
+      suitcase?: Palette['primary']
+      lights?: Palette['primary']
+      fetaldoppler?: Palette['primary']
+      headlamp?: Palette['primary']
+      charger?: Palette['primary']
+      phonecharger?: Palette['primary']
     }
-}
-
+    interface PaletteOptions {
+      main?: PaletteOptions['primary']
+      general?: PaletteOptions['primary']
+      suitcase?: PaletteOptions['primary']
+      lights?: PaletteOptions['primary']
+      fetaldoppler?: PaletteOptions['primary']
+      headlamp?: PaletteOptions['primary']
+      charger?: PaletteOptions['primary']
+      phonecharger?: PaletteOptions['primary']
+    }
+  }
 
 
 const theme  = createMuiTheme({
     palette: {
-        myCustomColor: {
-            yellow: '#EFC477'
+        main: {
+          main: '#F6DBB7',
+          dark: '4F2A1D'
+        },
+        general: { 
+          main: '#F7F4F3',
+          dark: '#231F20'
         }, 
-        primary: {
-
+        suitcase: {
+          main: '#9FB8D8', 
+          dark: '#2A5375'
         }, 
-        secondary: {
-
+        lights: {
+          main: '#FCEBD5',
+          dark: '#DBB079'
         }, 
-
+        fetaldoppler: {
+          main: '#777CA6',
+          dark: '#4B5288'
+        },
+        headlamp: {
+          main: '#D49BA9',
+          dark: '#C0677D'
+        },
+        charger: {
+          main: '#DBE2E7',
+          dark: '#4D6A6D'
+        },
+        phonecharger: {
+          main: '#E4CDC7',
+          dark: '#BD9084'
+        },
     }
 })
 

--- a/src/CustomStyles.tsx
+++ b/src/CustomStyles.tsx
@@ -4,6 +4,18 @@ import { Palette } from "@material-ui/core/styles/createPalette";
 
 declare module '@material-ui/core/styles/createPalette' {
     interface Palette {
+      //main colors 
+      black: Palette['primary']
+      white?: Palette['primary']
+      brown?: Palette['primary']
+      yellow: Palette['primary']
+      accent1?: Palette['primary']
+      accent2?: Palette['primary']
+      accent3?: Palette['primary']
+      //troubleshooting buttons
+      tshootyes?: Palette['primary']
+      tshootno?: Palette['primary']
+      //appliances 
       main?: Palette['primary']
       general?: Palette['primary']
       suitcase?: Palette['primary']
@@ -12,8 +24,21 @@ declare module '@material-ui/core/styles/createPalette' {
       headlamp?: Palette['primary']
       charger?: Palette['primary']
       phonecharger?: Palette['primary']
+      thermometer?: Palette['primary']
     }
     interface PaletteOptions {
+      //main colors 
+      black: PaletteOptions['primary']
+      white?: PaletteOptions['primary']
+      brown?: PaletteOptions['primary']
+      yellow: PaletteOptions['primary']
+      accent1?: PaletteOptions['primary']
+      accent2?: PaletteOptions['primary']
+      accent3?: PaletteOptions['primary']
+      //troubleshooting buttons
+      tshootyes?: PaletteOptions['primary']
+      tshootno?: PaletteOptions['primary']
+      //applicances 
       main?: PaletteOptions['primary']
       general?: PaletteOptions['primary']
       suitcase?: PaletteOptions['primary']
@@ -22,12 +47,42 @@ declare module '@material-ui/core/styles/createPalette' {
       headlamp?: PaletteOptions['primary']
       charger?: PaletteOptions['primary']
       phonecharger?: PaletteOptions['primary']
+      thermometer?: PaletteOptions['primary']
     }
   }
 
 
 const theme  = createMuiTheme({
     palette: {
+      black: {
+        main: "#333333",
+      },
+      white: {
+        main: "#FFFFFF",
+      },
+      brown: {
+        main: "#4F2A1D",
+      },
+      yellow: {
+        main: "#F6DBB7",
+      },
+      accent1: {
+        main: "#F6DBB7",
+      },
+      accent2: {
+        main: "#C0677D",
+      },
+      accent3: {
+        main: "#B7B7B7",
+      },
+      //troubleshooting buttons 
+      tshootyes: {
+        main: "#96B892",
+      },
+      tshootno: {
+        main: "#B99291",
+      },
+      //applicances 
         main: {
           main: '#F6DBB7',
           dark: '4F2A1D'

--- a/src/CustomStyles.tsx
+++ b/src/CustomStyles.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { createMuiTheme, Theme } from '@material-ui/core/styles';
+
+
+declare module '@material-ui/core/styles/createPalette' {
+    interface Palette {
+        myCustomColor: Palette['primary']; 
+    }
+}
+
+
+
+const theme  = createMuiTheme({
+    palette: {
+        myCustomColor: {
+            yellow: '#EFC477'
+        }, 
+        primary: {
+
+        }, 
+        secondary: {
+
+        }, 
+
+    }
+})
+
+export default theme; 
+

--- a/src/CustomStyles.tsx
+++ b/src/CustomStyles.tsx
@@ -83,38 +83,38 @@ const theme  = createMuiTheme({
         main: "#B99291",
       },
       //applicances 
-        main: {
-          main: '#F6DBB7',
-          dark: '4F2A1D'
-        },
-        general: { 
-          main: '#F7F4F3',
-          dark: '#231F20'
-        }, 
-        suitcase: {
-          main: '#9FB8D8', 
-          dark: '#2A5375'
-        }, 
-        lights: {
-          main: '#FCEBD5',
-          dark: '#DBB079'
-        }, 
-        fetaldoppler: {
-          main: '#777CA6',
-          dark: '#4B5288'
-        },
-        headlamp: {
-          main: '#D49BA9',
-          dark: '#C0677D'
-        },
-        charger: {
-          main: '#DBE2E7',
-          dark: '#4D6A6D'
-        },
-        phonecharger: {
-          main: '#E4CDC7',
-          dark: '#BD9084'
-        },
+      main: {
+        main: '#F6DBB7',
+        dark: '4F2A1D'
+      },
+      general: { 
+        main: '#F7F4F3',
+        dark: '#231F20'
+      }, 
+      suitcase: {
+        main: '#9FB8D8', 
+        dark: '#2A5375'
+      }, 
+      lights: {
+        main: '#FCEBD5',
+        dark: '#DBB079'
+      }, 
+      fetaldoppler: {
+        main: '#777CA6',
+        dark: '#4B5288'
+      },
+      headlamp: {
+        main: '#D49BA9',
+        dark: '#C0677D'
+      },
+      charger: {
+        main: '#DBE2E7',
+        dark: '#4D6A6D'
+      },
+      phonecharger: {
+        main: '#E4CDC7',
+        dark: '#BD9084'
+      },
     }
 })
 

--- a/src/CustomStyles.tsx
+++ b/src/CustomStyles.tsx
@@ -1,53 +1,52 @@
 import React from 'react';
 import { createMuiTheme, Theme } from '@material-ui/core/styles';
-import { Palette } from "@material-ui/core/styles/createPalette";
 
 declare module '@material-ui/core/styles/createPalette' {
     interface Palette {
       //main colors 
       black: Palette['primary']
-      white?: Palette['primary']
-      brown?: Palette['primary']
+      white: Palette['primary']
+      brown: Palette['primary']
       yellow: Palette['primary']
-      accent1?: Palette['primary']
-      accent2?: Palette['primary']
-      accent3?: Palette['primary']
+      accent1: Palette['primary']
+      accent2: Palette['primary']
+      accent3: Palette['primary']
       //troubleshooting buttons
-      tshootyes?: Palette['primary']
-      tshootno?: Palette['primary']
+      tshootyes: Palette['primary']
+      tshootno: Palette['primary']
       //appliances 
-      main?: Palette['primary']
-      general?: Palette['primary']
-      suitcase?: Palette['primary']
-      lights?: Palette['primary']
-      fetaldoppler?: Palette['primary']
-      headlamp?: Palette['primary']
-      charger?: Palette['primary']
-      phonecharger?: Palette['primary']
-      thermometer?: Palette['primary']
+      main: Palette['primary']
+      general: Palette['primary']
+      suitcase: Palette['primary']
+      lights: Palette['primary']
+      fetaldoppler: Palette['primary']
+      headlamp: Palette['primary']
+      charger: Palette['primary']
+      phonecharger: Palette['primary']
+      thermometer: Palette['primary']
     }
     interface PaletteOptions {
       //main colors 
       black: PaletteOptions['primary']
-      white?: PaletteOptions['primary']
-      brown?: PaletteOptions['primary']
+      white: PaletteOptions['primary']
+      brown: PaletteOptions['primary']
       yellow: PaletteOptions['primary']
-      accent1?: PaletteOptions['primary']
-      accent2?: PaletteOptions['primary']
-      accent3?: PaletteOptions['primary']
+      accent1: PaletteOptions['primary']
+      accent2: PaletteOptions['primary']
+      accent3: PaletteOptions['primary']
       //troubleshooting buttons
-      tshootyes?: PaletteOptions['primary']
-      tshootno?: PaletteOptions['primary']
+      tshootyes: PaletteOptions['primary']
+      tshootno: PaletteOptions['primary']
       //applicances 
-      main?: PaletteOptions['primary']
-      general?: PaletteOptions['primary']
-      suitcase?: PaletteOptions['primary']
-      lights?: PaletteOptions['primary']
-      fetaldoppler?: PaletteOptions['primary']
-      headlamp?: PaletteOptions['primary']
-      charger?: PaletteOptions['primary']
-      phonecharger?: PaletteOptions['primary']
-      thermometer?: PaletteOptions['primary']
+      main: PaletteOptions['primary']
+      general: PaletteOptions['primary']
+      suitcase: PaletteOptions['primary']
+      lights: PaletteOptions['primary']
+      fetaldoppler: PaletteOptions['primary']
+      headlamp: PaletteOptions['primary']
+      charger: PaletteOptions['primary']
+      phonecharger: PaletteOptions['primary']
+      thermometer: PaletteOptions['primary']
     }
   }
 
@@ -114,6 +113,10 @@ const theme  = createMuiTheme({
       phonecharger: {
         main: '#E4CDC7',
         dark: '#BD9084'
+      },
+      thermometer: {
+        main: '#E4CFCA',
+        dark: '#BC8273'
       },
     }
 })

--- a/src/components/Cards/PreviewCardStyles.ts
+++ b/src/components/Cards/PreviewCardStyles.ts
@@ -1,8 +1,6 @@
-
 export const styles = {
-    root: {
-    },
-    title: {
-        fontSize: 20
-    }
+  root: {},
+  title: {
+    fontSize: 20
+  }
 };

--- a/src/components/SearchBar/SearchBarStyles.ts
+++ b/src/components/SearchBar/SearchBarStyles.ts
@@ -1,37 +1,37 @@
 import { createStyles, Theme, fade } from '@material-ui/core/styles';
 export const styles = (theme: Theme) =>
-    createStyles({
-        root: {
-            flexGrow: 1,
-            width: '100%',
-            position: "fixed",
-            top: 0,
-        },
-        search: {
-            position: 'relative',
-            borderRadius: 10,
-            backgroundColor: fade(theme.palette.common.white, 0.15),
-            width: '100%',
-            margin: 10
-        },
-        searchIcon: {
-            padding: theme.spacing(0, 2),
-            height: '100%',
-            position: 'absolute',
-            pointerEvents: 'none',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center'
-        },
-        inputRoot: {
-            color: 'inherit',
-            width: '100%'
-        },
-        inputInput: {
-            padding: theme.spacing(1, 1, 1, 0),
-            // vertical padding + font size from searchIcon
-            paddingLeft: `calc(1em + ${theme.spacing(4)}px)`,
-            width: '100%',
-            flexGrow: 1
-        }
-    });
+  createStyles({
+    root: {
+      flexGrow: 1,
+      width: '100%',
+      position: 'fixed',
+      top: 0
+    },
+    search: {
+      position: 'relative',
+      borderRadius: 10,
+      backgroundColor: fade(theme.palette.common.white, 0.15),
+      width: '100%',
+      margin: 10
+    },
+    searchIcon: {
+      padding: theme.spacing(0, 2),
+      height: '100%',
+      position: 'absolute',
+      pointerEvents: 'none',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center'
+    },
+    inputRoot: {
+      color: 'inherit',
+      width: '100%'
+    },
+    inputInput: {
+      padding: theme.spacing(1, 1, 1, 0),
+      // vertical padding + font size from searchIcon
+      paddingLeft: `calc(1em + ${theme.spacing(4)}px)`,
+      width: '100%',
+      flexGrow: 1
+    }
+  });

--- a/src/pages/Guides/GuidesStyles.ts
+++ b/src/pages/Guides/GuidesStyles.ts
@@ -1,11 +1,11 @@
 import { createStyles, Theme } from '@material-ui/core/styles';
 export const styles = (theme: Theme) =>
-    createStyles({
-        playlistScroll: {
-            display: "flex",
-            overflow: "scroll"
-        },
-        playlistCard: {
-            width: "300px"
-        }
-    });
+  createStyles({
+    playlistScroll: {
+      display: 'flex',
+      overflow: 'scroll'
+    },
+    playlistCard: {
+      width: '300px'
+    }
+  });


### PR DESCRIPTION
## 🖋 PR Description

Custom theming using latest design color palette. 

**How to read with respect to figma style guide**
- For general options (yellow, black, etc), access colors using `[color].main` 
- For appliances (lights, fetal doppler, etc), access background colors using `[appliance name].main` and text colors using `[appliance name].dark` 

### 🤳Screenshots (if applicable)

### 🐞 Bug Report

### 🧪 Testing

How do we test your feature?
To access any color from the custom palette, use `theme.palette.[color].[main/dark]` 

cc: @joelenelatief
