### PR TITLE
Avoid using Firebase Messaging on unsupported devices

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,7 +25,8 @@ firebase.initializeApp({
   appId: '1:963041613875:web:96e9b6562a9a7c4cd76b46',
   measurementId: 'G-N48ZSWDGHL'
 });
-export const messaging = firebase.messaging();
+export const messaging = 
+  firebase.messaging.isSupported() ? firebase.messaging() : null;
 export const db = firebase.firestore();
 
 db.enablePersistence()

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,7 +41,13 @@ db.enablePersistence()
     }
   });
 
-initializePushNotifications();
+if (firebase.messaging.isSupported()) {
+  initializePushNotifications();
+} else {
+  console.log("Warning: On a device that does not supported Firebase Messaging."
+   + "Will skip setting up push notifications.")
+}
+
 loadInitialState();
 
 // Set up IndexedDB store for caching videos

--- a/src/pushNotifications.ts
+++ b/src/pushNotifications.ts
@@ -26,7 +26,7 @@ const VAPID_KEY =
 export const initializePushNotifications = () => {
   // Called when a notification is received while the app is in the foreground,
   // or the user clicks on a notification that was sent while in the background
-  messaging.onMessage((payload) => {
+  messaging!.onMessage((payload) => {
     console.log('[firebase-messaging-sw.js] Received message in app ', payload);
   });
   retrievePushToken();
@@ -36,7 +36,7 @@ export const initializePushNotifications = () => {
 // If no token exists, will request push permission first, then automatically call this function again.
 const retrievePushToken = () => {
   console.log('Attempting to retrieve push token...');
-  messaging
+  messaging!
     .getToken({ vapidKey: VAPID_KEY })
     .then((currentToken) => {
       if (currentToken) {


### PR DESCRIPTION
## 🖋 PR Description

Avoids initializing Firebase Messaging for push notifications on devices/browsers that don't support it (e.g. Safari).


cc: @susan-lin 
