### PR TITLE
Remove stray semicolon from See All list

### DIFF
--- a/src/components/SeeAll.tsx
+++ b/src/components/SeeAll.tsx
@@ -59,7 +59,7 @@ function SeeAll(props: SeeAllProps) {
             {articles.map((key: any) => (
               <Link style={{ textDecoration: 'none' }} to={`${props.match.url}/${key}`}>
                 <div className={classes.articlesCard}>
-                  <StandardCard resource={resources[key]} resourceID={key} completeCheck={false} collapsed={false} />;
+                  <StandardCard resource={resources[key]} resourceID={key} completeCheck={false} collapsed={false} />
               </div>
               </Link>
             ))}


### PR DESCRIPTION
## 🖋 PR Description

* Drops stray `;` from the See All list (unnecessary and treated as real character in JSX)

### 🤳Screenshots (if applicable)

![image](https://user-images.githubusercontent.com/2977329/115130576-9dc0a380-9fa5-11eb-991d-c268894e3571.png)

cc: @joelenelatief
