### PR TITLE
unpreserved scrolling with new ScrollToTop component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import TroubleShootCard from './components/Troubleshoot/TroubleShootCard';
 import { ThemeProvider } from '@material-ui/core/styles';
 import theme from './CustomStyles';
 import SeeAll from './components/SeeAll';
-
+import ScrollToTop from './ScrollToTop';
 import Article from './components/Article/Article';
 import WCSRoute from './WCSRoute';
 
@@ -39,6 +39,7 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <Router>
+        <ScrollToTop />
         <div className={classes.root}>
           {!didInitialLoad ? (
             <div>Loading...</div>

--- a/src/ScrollToTop.tsx
+++ b/src/ScrollToTop.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import { withRouter } from 'react-router-dom';
+
+function ScrollToTop({ history }) {
+  useEffect(() => {
+    const unlisten = history.listen(() => {
+      window.scrollTo(0, 0);
+    });
+    return () => {
+      unlisten();
+    };
+  }, []);
+
+  return null;
+}
+
+export default withRouter(ScrollToTop);


### PR DESCRIPTION
## 🖋 PR Description

See title 

Notes: 

- `withRouter` will pass updated match, location, and history props to the wrapped component whenever it renders.
- we use a React hook to watch for changes in the history parameter, and return `window.scrollTo(0, 0)` whenever it triggers. 

Resources: 
- https://reactrouter.com/web/guides/scroll-restoration
- https://stackoverflow.com/questions/36904185/react-router-scroll-to-top-on-every-transition




cc: @susan-lin
